### PR TITLE
Change return type from 'meeting' to 'meetings'

### DIFF
--- a/packages/schema/src/schema.ts
+++ b/packages/schema/src/schema.ts
@@ -4606,7 +4606,7 @@ export const schema: SchemaV1 = build_schema({
         parameters: { 
           id: { validator: mongoIdStringValidator },
         },
-        returns: 'meeting' as any,
+        returns: 'meetings' as any,
       },
       start_meeting: {
         op: "custom", access: 'create', method: "post",


### PR DESCRIPTION
Issue with openapi.json
1. `git clone https://github.com/tellescope/tellescope.git`
2. `cd tellescope/packages/schema/`
3. `npm install`
4. `npm run build`
5. `npx --yes @redocly/cli@latest lint openapi.json 2>&1 | grep -B3 -A15 "Can't resolve"`
6. Look at the error `❌ Validation failed with 1 error and 307 warnings.`

Fix:
1. File: packages/schema/src/schema.ts, line 4609 (the meetings.read action):

        returns: 'meeting' as any,     // before
        returns: 'meetings' as any,    // after  ('meeting' -> 'meetings')
2. `npm install`
3. `npm run build`
4. `node lib/cjs/generate-openapi.js openapi.json`
5. `npx --yes @redocly/cli@latest lint openapi.json`
6. no error `Woohoo! Your API description is valid. 🎉`
